### PR TITLE
NCSD-3300-App-setting-fix

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -397,7 +397,7 @@
               },
               {
                 "name": "BlobStorageSettings__Container",
-                "value": "faoc-flies"
+                "value": "faoc-files"
               },
               {
                 "name": "BlobStorageSettings__ConnectionString",


### PR DESCRIPTION
Fixed a typo on BlobstorageSettings_container app settings

app setting has faoc-flies, rather then faoc-files